### PR TITLE
add new font cache file (dont remove old one in case they downgrade)

### DIFF
--- a/fonts/dompdf_font_family_cache.php
+++ b/fonts/dompdf_font_family_cache.php
@@ -1,0 +1,111 @@
+<?php return array (
+  'sans-serif' =>
+  array (
+    'normal' => DOMPDF_FONT_DIR . 'Helvetica',
+    'bold' => DOMPDF_FONT_DIR . 'Helvetica-Bold',
+    'italic' => DOMPDF_FONT_DIR . 'Helvetica-Oblique',
+    'bold_italic' => DOMPDF_FONT_DIR . 'Helvetica-BoldOblique',
+  ),
+  'times' =>
+  array (
+    'normal' => DOMPDF_FONT_DIR . 'Times-Roman',
+    'bold' => DOMPDF_FONT_DIR . 'Times-Bold',
+    'italic' => DOMPDF_FONT_DIR . 'Times-Italic',
+    'bold_italic' => DOMPDF_FONT_DIR . 'Times-BoldItalic',
+  ),
+  'times-roman' =>
+  array (
+    'normal' => DOMPDF_FONT_DIR . 'Times-Roman',
+    'bold' => DOMPDF_FONT_DIR . 'Times-Bold',
+    'italic' => DOMPDF_FONT_DIR . 'Times-Italic',
+    'bold_italic' => DOMPDF_FONT_DIR . 'Times-BoldItalic',
+  ),
+  'courier' =>
+  array (
+    'normal' => DOMPDF_FONT_DIR . 'Courier',
+    'bold' => DOMPDF_FONT_DIR . 'Courier-Bold',
+    'italic' => DOMPDF_FONT_DIR . 'Courier-Oblique',
+    'bold_italic' => DOMPDF_FONT_DIR . 'Courier-BoldOblique',
+  ),
+  'helvetica' =>
+  array (
+    'normal' => DOMPDF_FONT_DIR . 'Helvetica',
+    'bold' => DOMPDF_FONT_DIR . 'Helvetica-Bold',
+    'italic' => DOMPDF_FONT_DIR . 'Helvetica-Oblique',
+    'bold_italic' => DOMPDF_FONT_DIR . 'Helvetica-BoldOblique',
+  ),
+//  'zapfdingbats' =>
+//  array (
+//    'normal' => DOMPDF_FONT_DIR . 'ZapfDingbats',
+//    'bold' => DOMPDF_FONT_DIR . 'ZapfDingbats',
+//    'italic' => DOMPDF_FONT_DIR . 'ZapfDingbats',
+//    'bold_italic' => DOMPDF_FONT_DIR . 'ZapfDingbats',
+//  ),
+//  'symbol' =>
+//  array (
+//    'normal' => DOMPDF_FONT_DIR . 'Symbol',
+//    'bold' => DOMPDF_FONT_DIR . 'Symbol',
+//    'italic' => DOMPDF_FONT_DIR . 'Symbol',
+//    'bold_italic' => DOMPDF_FONT_DIR . 'Symbol',
+//  ),
+  'serif' =>
+  array (
+    'normal' => DOMPDF_FONT_DIR . 'Times-Roman',
+    'bold' => DOMPDF_FONT_DIR . 'Times-Bold',
+    'italic' => DOMPDF_FONT_DIR . 'Times-Italic',
+    'bold_italic' => DOMPDF_FONT_DIR . 'Times-BoldItalic',
+  ),
+  'monospace' =>
+  array (
+    'normal' => DOMPDF_FONT_DIR . 'Courier',
+    'bold' => DOMPDF_FONT_DIR . 'Courier-Bold',
+    'italic' => DOMPDF_FONT_DIR . 'Courier-Oblique',
+    'bold_italic' => DOMPDF_FONT_DIR . 'Courier-BoldOblique',
+  ),
+  'fixed' =>
+  array (
+    'normal' => DOMPDF_FONT_DIR . 'Courier',
+    'bold' => DOMPDF_FONT_DIR . 'Courier-Bold',
+    'italic' => DOMPDF_FONT_DIR . 'Courier-Oblique',
+    'bold_italic' => DOMPDF_FONT_DIR . 'Courier-BoldOblique',
+  ),
+  'dejavu sans' =>
+  array (
+    'bold' => DOMPDF_FONT_DIR . 'DejaVuSans-Bold',
+    'bold_italic' => DOMPDF_FONT_DIR . 'DejaVuSans-BoldOblique',
+    'italic' => DOMPDF_FONT_DIR . 'DejaVuSans-Oblique',
+    'normal' => DOMPDF_FONT_DIR . 'DejaVuSans',
+  ),
+  'dejavu sans light' =>
+  array (
+    'normal' => DOMPDF_FONT_DIR . 'DejaVuSans-ExtraLight',
+  ),
+//  'dejavu sans condensed' =>
+//  array (
+//    'bold' => DOMPDF_FONT_DIR . 'DejaVuSansCondensed-Bold',
+//    'bold_italic' => DOMPDF_FONT_DIR . 'DejaVuSansCondensed-BoldOblique',
+//    'italic' => DOMPDF_FONT_DIR . 'DejaVuSansCondensed-Oblique',
+//    'normal' => DOMPDF_FONT_DIR . 'DejaVuSansCondensed',
+//  ),
+//  'dejavu sans mono' =>
+//  array (
+//    'bold' => DOMPDF_FONT_DIR . 'DejaVuSansMono-Bold',
+//    'bold_italic' => DOMPDF_FONT_DIR . 'DejaVuSansMono-BoldOblique',
+//    'italic' => DOMPDF_FONT_DIR . 'DejaVuSansMono-Oblique',
+//    'normal' => DOMPDF_FONT_DIR . 'DejaVuSansMono',
+//  ),
+//  'dejavu serif' =>
+//  array (
+//    'bold' => DOMPDF_FONT_DIR . 'DejaVuSerif-Bold',
+//    'bold_italic' => DOMPDF_FONT_DIR . 'DejaVuSerif-BoldItalic',
+//    'italic' => DOMPDF_FONT_DIR . 'DejaVuSerif-Italic',
+//    'normal' => DOMPDF_FONT_DIR . 'DejaVuSerif',
+//  ),
+//  'dejavu serif condensed' =>
+//  array (
+//    'bold' => DOMPDF_FONT_DIR . 'DejaVuSerifCondensed-Bold',
+//    'bold_italic' => DOMPDF_FONT_DIR . 'DejaVuSerifCondensed-BoldItalic',
+//    'italic' => DOMPDF_FONT_DIR . 'DejaVuSerifCondensed-Italic',
+//    'normal' => DOMPDF_FONT_DIR . 'DejaVuSerifCondensed',
+//  ),
+) ?>


### PR DESCRIPTION
We're upgrading DOMPDF in EE core to 0.8.2, where the font cache file's filetype is just `.php` instead of `.dist.php`.
In order for this add-on to correctly inform DOMPDF of other font files, we need to update the file's filetype.
In this commit, I just added a new font cache file. I didn't remove the old one so this version of the add-on will continue to work with EE 4.9.66 and lower